### PR TITLE
:zap: lower uwsgi workers CPU usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,34 @@ Connect to mongodb
 ```
 $ docker-compose run --rm --user mongodb mongo sh -c 'mongo --host mongo --username="${MONGO_INITDB_ROOT_USERNAME}" --password="${MONGO_INITDB_ROOT_PASSWORD}"'
 ```
+
+Import data into database
+-------------------------
+
+Execute a `mongodump` of an instance of the 
+[SMARTER-database](https://github.com/cnr-ibba/SMARTER-database) project, for 
+example:
+
+```
+$ docker-compose run --rm --user mongodb mongo sh -c 'DATE=$(date +%Y-%m-%d); mongodump --host mongo --username="${MONGO_INITDB_ROOT_USERNAME}" --password="${MONGO_INITDB_ROOT_PASSWORD}" --authenticationDatabase admin --db=smarter --gzip --archive=/home/mongodb/${DATE}\_smarter.archive.gz'
+```
+
+Then copy (or move) the dump file into `mongodb-home` folder of this project. You
+can restore the database using `mongorestore`, for example:
+
+```
+$ docker-compose run --rm --user mongodb mongo sh -c 'mongorestore --host mongo --username="${MONGO_INITDB_ROOT_USERNAME}" --password="${MONGO_INITDB_ROOT_PASSWORD}" --authenticationDatabase admin --db=smarter --drop --preserveUUID --gzip --archive=/home/mongodb/2021-06-18_smarter.archive.gz'
+```
+
+Monitoring UWSGI processes
+--------------------------
+
+Enter inside uwsgi container (with `docker-compose exec`), then monitor uwsgi with 
+[uwsgitop](https://github.com/xrmx/uwsgitop):
+
+```
+$ docker-compose exec uwsgi bash
+# uwsgitop /tmp/smarter-stats.sock
+```
+
+Type `q` to exit from monitoring process

--- a/flask-data/smarter_uwsgi.ini
+++ b/flask-data/smarter_uwsgi.ini
@@ -32,6 +32,10 @@ master          = true
 # maximum number of worker processes
 processes       = 4
 
+# enable threads 
+# (https://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html?highlight=enable-threads)
+enable-threads  = true
+
 # the socket (use the full path to be safe)
 socket          = /tmp/smarter.sock
 
@@ -41,6 +45,11 @@ chown-socket    = www-data:www-data
 
 # clear environment on exit
 vacuum          = true
+
+# uWSGI also supports a Stats Server mechanism which exports 
+# the uWSGI state as a JSON object to a socket
+# (required for uwsgitop)
+stats           = /tmp/smarter-stats.sock
 
 #uWSGI options for a deployment in production include:
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -9,7 +9,9 @@
 # Get the last stable nginx image
 FROM nginx:1.20
 
-MAINTAINER Paolo Cozzi <cozzi@ibba.cnr.it>
+LABEL maintainer="Paolo Cozzi <paolo.cozzi@ibba.cnr.it>" \
+      description="A nginx container to work with flask" \
+      version="0.1"
 
 # synchronize timezone for container
 # https://forums.docker.com/t/synchronize-timezone-from-host-to-container/39116

--- a/uwsgi/Dockerfile
+++ b/uwsgi/Dockerfile
@@ -1,15 +1,17 @@
 
 #
-# VERSION 0.1
+# VERSION 0.2
 # DOCKER-VERSION  20.10.6
 # AUTHOR:         Paolo Cozzi <cozzi@ibba.cnr.it>
-# DESCRIPTION:    A flask container working on flask
+# DESCRIPTION:    A flask container working with mongoengine
 #
 
 # start from a python base image
 FROM python:3.9
 
-MAINTAINER Paolo Cozzi <cozzi@ibba.cnr.it>
+LABEL maintainer="Paolo Cozzi <paolo.cozzi@ibba.cnr.it>" \
+      description="A flask container working with mongoengine" \
+      version="0.2"
 
 # synchronize timezone for container
 # https://forums.docker.com/t/synchronize-timezone-from-host-to-container/39116
@@ -30,6 +32,15 @@ EXPOSE 5000
 
 # This environment variable force stdin, stdout and stderr to be totally unbuffered
 ENV PYTHONUNBUFFERED 1
+
+# Elegantly activating a virtualenv in a Dockerfile
+# https://pythonspeed.com/articles/activate-virtualenv-dockerfile/
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Upgrade pip to latest version
+RUN python3 -m pip install --upgrade pip wheel
 
 # Install pypi modules (uwsgi)
 COPY requirements.txt /root/

--- a/uwsgi/requirements.txt
+++ b/uwsgi/requirements.txt
@@ -1,5 +1,6 @@
 Flask==2.0.1
 uWSGI==2.0.19.1
+uwsgitop==0.11
 flask-restful==0.3.9
 flask-mongoengine==1.0.0
 flask-bcrypt==0.7.1


### PR DESCRIPTION
This PR will add those new features:

- Lower CPU usage of `uwsgi` workers (resolve #15)
- Install `uwsgitop` monitoring package
- Remove warning when building `uwsgi` docker image (install packages using `virtualenv`, see [Elegantly activating a virtualenv in a Dockerfile](https://pythonspeed.com/articles/activate-virtualenv-dockerfile/))
- Update `README.md`
